### PR TITLE
Update DBS sys2sys communication dependencies

### DIFF
--- a/service-sdk/10.0.0/add-persistence-to-service/example-service/pom.xml
+++ b/service-sdk/10.0.0/add-persistence-to-service/example-service/pom.xml
@@ -65,11 +65,15 @@
 
         <!-- Add dependencies for your services, e.g. BB raml specifications, integration clients -->
 
-        <!-- Uncomment the following dependency if DBS inter-service communication is needed -->
+        <!-- Uncomment the following dependencies if DBS inter-service communication is needed -->
         <!--
              <dependency>
                 <groupId>com.backbase.buildingblocks</groupId>
                 <artifactId>communication</artifactId>
+             </dependency>
+             <dependency>
+                <groupId>com.backbase.buildingblocks</groupId>
+                <artifactId>auth-security</artifactId>
              </dependency>
            -->
     </dependencies>

--- a/service-sdk/10.0.0/create-core-service/example-service/pom.xml
+++ b/service-sdk/10.0.0/create-core-service/example-service/pom.xml
@@ -32,11 +32,15 @@
 
         <!-- Add dependencies for your services, e.g. BB raml specifications, integration clients -->
 
-        <!-- Uncomment the following dependency if DBS inter-service communication is needed -->
+        <!-- Uncomment the following dependencies if DBS inter-service communication is needed -->
         <!--
              <dependency>
                 <groupId>com.backbase.buildingblocks</groupId>
                 <artifactId>communication</artifactId>
+             </dependency>
+             <dependency>
+                <groupId>com.backbase.buildingblocks</groupId>
+                <artifactId>auth-security</artifactId>
              </dependency>
            -->
     </dependencies>

--- a/service-sdk/10.0.0/create-outbound-integration-service/example-integration-service/pom.xml
+++ b/service-sdk/10.0.0/create-outbound-integration-service/example-integration-service/pom.xml
@@ -43,11 +43,15 @@
 
         <!-- Add dependencies for your services, e.g. BB raml specifications, integration clients -->
 
-        <!-- Uncomment the following dependency if DBS inter-service communication is needed -->
+        <!-- Uncomment the following dependencies if DBS inter-service communication is needed -->
         <!--
              <dependency>
                 <groupId>com.backbase.buildingblocks</groupId>
                 <artifactId>communication</artifactId>
+             </dependency>
+             <dependency>
+                <groupId>com.backbase.buildingblocks</groupId>
+                <artifactId>auth-security</artifactId>
              </dependency>
            -->
     </dependencies>

--- a/service-sdk/10.0.0/include-persistence-crud-service-specification/example-service/pom.xml
+++ b/service-sdk/10.0.0/include-persistence-crud-service-specification/example-service/pom.xml
@@ -73,11 +73,15 @@
 
         <!-- Add dependencies for your services, e.g. BB raml specifications, integration clients -->
 
-        <!-- Uncomment the following dependency if DBS inter-service communication is needed -->
+        <!-- Uncomment the following dependencies if DBS inter-service communication is needed -->
         <!--
              <dependency>
                 <groupId>com.backbase.buildingblocks</groupId>
                 <artifactId>communication</artifactId>
+             </dependency>
+             <dependency>
+                <groupId>com.backbase.buildingblocks</groupId>
+                <artifactId>auth-security</artifactId>
              </dependency>
            -->
     </dependencies>

--- a/service-sdk/10.0.0/migrate-to-open-api/messaging-service/pom.xml
+++ b/service-sdk/10.0.0/migrate-to-open-api/messaging-service/pom.xml
@@ -75,11 +75,15 @@
 
         <!-- Add dependencies for your services, e.g. BB raml specifications, integration clients -->
 
-        <!-- Uncomment the following dependency if DBS inter-service communication is needed -->
+        <!-- Uncomment the following dependencies if DBS inter-service communication is needed -->
         <!--
              <dependency>
                 <groupId>com.backbase.buildingblocks</groupId>
                 <artifactId>communication</artifactId>
+             </dependency>
+             <dependency>
+                <groupId>com.backbase.buildingblocks</groupId>
+                <artifactId>auth-security</artifactId>
              </dependency>
            -->
     </dependencies>


### PR DESCRIPTION
The current docs are misleading as you require the `auth-security` dependency to enable sys2sys comms between DBS capabilities.