### PR TITLE
Name the bean method after your Api class.

### DIFF
--- a/service-sdk/13.0.0/create-openapi-client/banking-service/src/main/java/com/backbase/banking/MessagingServiceRestClientConfiguration.java
+++ b/service-sdk/13.0.0/create-openapi-client/banking-service/src/main/java/com/backbase/banking/MessagingServiceRestClientConfiguration.java
@@ -19,12 +19,12 @@ public class MessagingServiceRestClientConfiguration extends ApiClientConfig {
     }
 
     /**
-     * Creates a REST client.
+     * Creates a REST client. Name the method after your Api class.
      *
      * @return the client.
      */
     @Bean
-    public MessageApi createGeneratedClassApiClient() {
+    public MessageApi messageApiClient() {
         return new MessageApi(createaApiClient());
     }
 


### PR DESCRIPTION
See https://backbase.atlassian.net/browse/MAINT-12574 for reasons.

Mitigate bean overriding.