### PR TITLE
[15.0.0] restore spec dependency 

### DIFF
--- a/service-sdk/15.0.0/include-persistence-crud-service-specification/example-crud-service/pom.xml
+++ b/service-sdk/15.0.0/include-persistence-crud-service-specification/example-crud-service/pom.xml
@@ -132,6 +132,7 @@
                 <artifactId>boat-maven-plugin</artifactId>
                 <version>${boat-maven-plugin.version}</version>
                 <executions>
+                    <!-- tag::spec-dependency[] -->
                     <execution>
                         <id>generate-client-api-code</id>
                         <goals>
@@ -144,6 +145,7 @@
                             <modelPackage>com.backbase.service.example.rest.spec.v1.model</modelPackage>
                         </configuration>
                     </execution>
+                    <!-- end::spec-dependency[] -->
                 </executions>
             </plugin>
 


### PR DESCRIPTION
Added a different spec dependency (referenced from boat), since the spec project doesn't include any code as it's generated in the service